### PR TITLE
Updated to Swashbuckle 4.0.1

### DIFF
--- a/AspNetCore.AzureAd.Swagger.csproj
+++ b/AspNetCore.AzureAd.Swagger.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.AzureAD.UI" Version="2.1.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="3.0.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="4.0.1" />
   </ItemGroup>
 
 </Project>

--- a/Startup.cs
+++ b/Startup.cs
@@ -84,7 +84,7 @@ namespace AspNetCore.AzureAd.Swagger
                 c.OAuthRealm(Configuration["AzureAD:ClientId"]);
                 c.OAuthAppName("My API V1");
                 c.OAuthScopeSeparator(" ");
-                c.OAuthAdditionalQueryStringParams(new { resource = Configuration["AzureAD:ClientId"] });
+                c.OAuthAdditionalQueryStringParams(new Dictionary<string, string>() { { "resource", Configuration["AzureAD:ClientId"] } });
                 c.SwaggerEndpoint("/swagger/v1/swagger.json", "My API V1");
             });
         }


### PR DESCRIPTION
Update to the next Major Version of Swashbuckle.

Changed the Input of the OAuthAdditionalQueryStringParams to `Dictionary<string, string>`

This was causing the following issue while compiling:
![grafik](https://user-images.githubusercontent.com/20532954/60134745-81d08a00-97a0-11e9-8c01-f7b2cb78dd4a.png)
